### PR TITLE
Use psabpf-ctl register command in PTF tests

### DIFF
--- a/backends/ebpf/tests/p4testdata/register-structs.p4
+++ b/backends/ebpf/tests/p4testdata/register-structs.p4
@@ -97,7 +97,7 @@ control ingress(inout headers hdr,
          if (tmp.srcAddr < (bit<32>)5) {
              tmp.srcAddr = (bit<32>)5;
          } else {
-             tmp.srcAddr = tmp.srcAddr + 10;
+             tmp.dstAddr = tmp.dstAddr + 13;
          }
          reg.write(reg_key, tmp);
     }

--- a/backends/ebpf/tests/ptf/bng.py
+++ b/backends/ebpf/tests/ptf/bng.py
@@ -149,11 +149,11 @@ class BNGTest(P4EbpfTest):
         key_vlan_id = "{}^0xffff".format(vlan_id) if vlan_valid else "0^0"
         key_inner_vlan_id = "{}^0xffff".format(inner_vlan_id) if inner_vlan_id is not None else "0^0"
         keys = [ingress_port, key_vlan_id, key_inner_vlan_id, vlan_valid_]
-        self.table_add(table="ingress_ingress_port_vlan", keys=keys, action=action_id, data=action_data)
+        self.table_add(table="ingress_ingress_port_vlan", key=keys, action=action_id, data=action_data)
 
     def set_egress_vlan(self, egress_port, vlan_id, push_vlan=False):
         action_id = 1 if push_vlan else 2
-        self.table_add(table="egress_egress_vlan", keys=[vlan_id, egress_port],
+        self.table_add(table="egress_egress_vlan", key=[vlan_id, egress_port],
                        action=action_id)
 
     def set_forwarding_type(self, ingress_port, eth_dstAddr, ethertype=ETH_TYPE_IPV4,
@@ -171,29 +171,29 @@ class BNGTest(P4EbpfTest):
 
         matches = [key_eth_dst, ingress_port, key_eth_type, key_ip_eth_type]
 
-        self.table_add(table="ingress_fwd_classifier", keys=matches, action=1, # set_forwarding_type
+        self.table_add(table="ingress_fwd_classifier", key=matches, action=1, # set_forwarding_type
                        data=[fwd_type])
 
     def add_forwarding_routing_v4_entry(self, ipv4_dstAddr, ipv4_pLen,
                                         egress_port, smac, dmac):
-        self.table_add(table="ingress_routing_v4", keys=["{}/{}".format(ipv4_dstAddr, ipv4_pLen)],
+        self.table_add(table="ingress_routing_v4", key=["{}/{}".format(ipv4_dstAddr, ipv4_pLen)],
                        action=1, data=[egress_port, smac, dmac])
 
     def add_next_vlan(self, port_id, new_vlan_id):
-        self.table_add(table="ingress_next_vlan", keys=[port_id],
+        self.table_add(table="ingress_next_vlan", key=[port_id],
                        action=1, data=[new_vlan_id])
 
     def add_next_double_vlan(self, port_id, new_vlan_id, new_inner_vlan_id):
-        self.table_add(table="ingress_next_vlan", keys=[port_id],
+        self.table_add(table="ingress_next_vlan", key=[port_id],
                        action=2, data=[new_vlan_id, new_inner_vlan_id])
 
     def set_upstream_pppoe_cp_table(self, pppoe_codes=()):
         for code in pppoe_codes:
-            self.table_add(table="ingress_t_pppoe_cp", keys=[code], action=1, priority=1)
+            self.table_add(table="ingress_t_pppoe_cp", key=[code], action=1, priority=1)
 
     def set_line_map(self, s_tag, c_tag, line_id):
         assert line_id != 0
-        self.table_add(table="ingress_t_line_map", keys=[s_tag, c_tag], action=1, data=[line_id])
+        self.table_add(table="ingress_t_line_map", key=[s_tag, c_tag], action=1, data=[line_id])
 
     def setup_line_v4(self, s_tag, c_tag, line_id, ipv4_addr,
                       pppoe_session_id, enabled=True):
@@ -207,15 +207,16 @@ class BNGTest(P4EbpfTest):
         # Upstream
         if enabled:
             # Enable upstream termination.
-            self.table_add(table="ingress_t_pppoe_term_v4", keys=[line_id, str(ipv4_addr), pppoe_session_id], action=1)
+            self.table_add(table="ingress_t_pppoe_term_v4", key=[line_id, str(ipv4_addr), pppoe_session_id], action=1)
 
         # Downstream
         if enabled:
-            self.table_add(table="ingress_t_line_session_map", keys=[line_id],
+            self.table_add(table="ingress_t_line_session_map", key=[line_id],
                            action=1, data=[pppoe_session_id])
         else:
-            self.table_add(table="ingress_t_line_session_map", keys=[line_id],
+            self.table_add(table="ingress_t_line_session_map", key=[line_id],
                            action=2)
+
 
 class PPPoEUpstreamTest(BNGTest):
 
@@ -260,6 +261,7 @@ class PPPoEUpstreamTest(BNGTest):
             pkt[Ether].dst = SWITCH_MAC
             pkt[IP].src = CLIENT_IP
             self.doRunTest(pkt)
+
 
 class PPPoEDownstreamTest(BNGTest):
 

--- a/backends/ebpf/tests/ptf/l2l3_acl.py
+++ b/backends/ebpf/tests/ptf/l2l3_acl.py
@@ -41,11 +41,11 @@ class L2L3SwitchTest(P4EbpfTest):
 
     def configure_port(self, port_id, vlan_id=None):
         if vlan_id is None:
-            self.table_add(table="ingress_tbl_ingress_vlan", keys=[port_id, 0], action=1)
-            self.table_add(table="egress_tbl_vlan_egress", keys=[port_id], action=1)
+            self.table_add(table="ingress_tbl_ingress_vlan", key=[port_id, 0], action=1)
+            self.table_add(table="egress_tbl_vlan_egress", key=[port_id], action=1)
         else:
-            self.table_add(table="ingress_tbl_ingress_vlan", keys=[port_id, 1], action=0)
-            self.table_add(table="egress_tbl_vlan_egress", keys=[port_id], action=2, data=[vlan_id])
+            self.table_add(table="ingress_tbl_ingress_vlan", key=[port_id, 1], action=0)
+            self.table_add(table="egress_tbl_vlan_egress", key=[port_id], action=2, data=[vlan_id])
 
     def setUp(self):
         super(L2L3SwitchTest, self).setUp()
@@ -76,9 +76,9 @@ class SwitchingTest(L2L3SwitchTest):
         testutils.verify_no_other_packets(self)
 
         # check connectivity between ports in VLAN 1
-        self.table_add(table="ingress_tbl_switching", keys=["00:00:00:00:00:01", 1], action=1, data=[5])
-        self.table_add(table="ingress_tbl_switching", keys=["00:00:00:00:00:02", 1], action=1, data=[6])
-        self.table_add(table="ingress_tbl_switching", keys=["00:00:00:00:00:03", 1], action=1, data=[8])
+        self.table_add(table="ingress_tbl_switching", key=["00:00:00:00:00:01", 1], action=1, data=[5])
+        self.table_add(table="ingress_tbl_switching", key=["00:00:00:00:00:02", 1], action=1, data=[6])
+        self.table_add(table="ingress_tbl_switching", key=["00:00:00:00:00:03", 1], action=1, data=[8])
         pkt = testutils.simple_udp_packet(eth_dst="00:00:00:00:00:03")
         pkt = pkt_add_vlan(pkt, vlan_vid=1)
         testutils.send_packet(self, PORT1, pkt)
@@ -99,8 +99,8 @@ class SwitchingTest(L2L3SwitchTest):
         testutils.verify_no_other_packets(self)
 
         # check connectivity between ports with no VLAN
-        self.table_add(table="ingress_tbl_switching", keys=["00:00:00:00:00:01", 0], action=1, data=[4])
-        self.table_add(table="ingress_tbl_switching", keys=["00:00:00:00:00:02", 0], action=1, data=[9])
+        self.table_add(table="ingress_tbl_switching", key=["00:00:00:00:00:01", 0], action=1, data=[4])
+        self.table_add(table="ingress_tbl_switching", key=["00:00:00:00:00:02", 0], action=1, data=[9])
         pkt = testutils.simple_udp_packet(eth_dst="00:00:00:00:00:02")
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet(self, pkt, PORT5)
@@ -109,14 +109,14 @@ class SwitchingTest(L2L3SwitchTest):
         testutils.verify_packet(self, pkt, PORT0)
 
         # check no connectivity between VLAN 1 and VLAN 2
-        self.table_add(table="ingress_tbl_switching", keys=["00:00:00:00:02:02", 2], action=1, data=[6])
+        self.table_add(table="ingress_tbl_switching", key=["00:00:00:00:02:02", 2], action=1, data=[6])
         pkt = testutils.simple_udp_packet(eth_dst="00:00:00:00:02:02")
         pkt = pkt_add_vlan(pkt, vlan_vid=1)
         testutils.send_packet(self, PORT1, pkt)
         testutils.verify_no_packet(self, pkt, PORT3)
 
         # check no connectivity between VLAN 1 and no VLAN ports
-        self.table_add(table="ingress_tbl_switching", keys=["00:00:00:00:03:02", 0], action=1, data=[4])
+        self.table_add(table="ingress_tbl_switching", key=["00:00:00:00:03:02", 0], action=1, data=[4])
         pkt = testutils.simple_udp_packet(eth_dst="00:00:00:00:02:02")
         pkt = pkt_add_vlan(pkt, vlan_vid=1)
         testutils.send_packet(self, PORT1, pkt)
@@ -126,10 +126,10 @@ class SwitchingTest(L2L3SwitchTest):
 class RoutingTest(L2L3SwitchTest):
 
     def runTest(self):
-        self.table_add(table="ingress_tbl_switching", keys=["00:00:00:00:02:02", 2], action=1, data=[7])
-        self.table_add(table="ingress_tbl_switching", keys=["00:00:00:00:00:01", 1], action=1, data=[5])
-        self.table_add(table="ingress_tbl_switching", keys=["00:00:00:00:00:02", 1], action=1, data=[6])
-        self.table_add(table="ingress_tbl_switching", keys=["00:00:00:00:00:03", 1], action=1, data=[8])
+        self.table_add(table="ingress_tbl_switching", key=["00:00:00:00:02:02", 2], action=1, data=[7])
+        self.table_add(table="ingress_tbl_switching", key=["00:00:00:00:00:01", 1], action=1, data=[5])
+        self.table_add(table="ingress_tbl_switching", key=["00:00:00:00:00:02", 1], action=1, data=[6])
+        self.table_add(table="ingress_tbl_switching", key=["00:00:00:00:00:03", 1], action=1, data=[8])
 
         # check no connectivity between VLAN 1 and VLAN 2
         pkt = testutils.simple_udp_packet(eth_dst="00:00:00:00:02:02")
@@ -138,7 +138,7 @@ class RoutingTest(L2L3SwitchTest):
         testutils.verify_no_packet(self, pkt, PORT2)
 
         # enable routing from VLAN 1 to VLAN 2
-        self.table_add(table="ingress_tbl_routable", keys=["00:00:00:00:01:01", 2], action=0)
+        self.table_add(table="ingress_tbl_routable", key=["00:00:00:00:01:01", 2], action=0)
 
         # create all possible actions                                                  smac                 dmac                vlan_id
         act1 = self.action_selector_add_action(selector="ingress_as", action=1, data=["00:00:00:00:01:02", "00:00:00:00:00:01", 1])
@@ -151,7 +151,7 @@ class RoutingTest(L2L3SwitchTest):
         self.action_selector_add_member_to_group(selector="ingress_as", group_ref=gid, member_ref=act3)
 
         # ActionSelector reference = gid (should be 1, but not guaranteed), is_group_ref=True
-        self.table_add(table="ingress_tbl_routing", keys=["20.0.0.0/24"], references=["group {}".format(gid)])
+        self.table_add(table="ingress_tbl_routing", key=["20.0.0.0/24"], references=["group {}".format(gid)])
 
         pkt = testutils.simple_udp_packet(eth_dst="00:00:00:00:01:33", ip_dst="20.0.0.2", ip_src="10.0.0.1")
         pkt = pkt_add_vlan(pkt, vlan_vid=2)

--- a/backends/ebpf/tests/ptf/l2l3_acl.py
+++ b/backends/ebpf/tests/ptf/l2l3_acl.py
@@ -177,7 +177,7 @@ class RoutingTest(L2L3SwitchTest):
 class MACLearningTest(L2L3SwitchTest):
 
     def runTest(self):
-        self.table_add(table="ingress_tbl_mac_learning", keys=["00:06:07:08:09:0a"], action=0)
+        self.table_add(table="ingress_tbl_mac_learning", key=["00:06:07:08:09:0a"], action=0)
         # should NOT generate learn digest
         pkt = testutils.simple_udp_packet(eth_src='00:06:07:08:09:0a')
         testutils.send_packet(self, PORT0, pkt)
@@ -222,11 +222,11 @@ class BroadcastTest(L2L3SwitchTest):
         self.multicast_group_add_member(group=3, egress_port=9)
 
         # no VLAN, Multicast group ID = 0
-        self.table_add(table="ingress_tbl_switching", keys=["ff:ff:ff:ff:ff:ff", 0], action=2, data=[3])
+        self.table_add(table="ingress_tbl_switching", key=["ff:ff:ff:ff:ff:ff", 0], action=2, data=[3])
         # VLAN 1, Multicast group ID = 1
-        self.table_add(table="ingress_tbl_switching", keys=["ff:ff:ff:ff:ff:ff", 1], action=2, data=[1])
+        self.table_add(table="ingress_tbl_switching", key=["ff:ff:ff:ff:ff:ff", 1], action=2, data=[1])
         # VLAN 2, Multicast group ID = 2
-        self.table_add(table="ingress_tbl_switching", keys=["ff:ff:ff:ff:ff:ff", 2], action=2, data=[2])
+        self.table_add(table="ingress_tbl_switching", key=["ff:ff:ff:ff:ff:ff", 2], action=2, data=[2])
 
         pkt = testutils.simple_udp_packet(eth_src='00:06:07:08:09:0a',
                                           eth_dst='ff:ff:ff:ff:ff:ff')
@@ -249,7 +249,7 @@ class BroadcastTest(L2L3SwitchTest):
 class ACLTest(L2L3SwitchTest):
 
     def runTest(self):
-        self.table_add(table="ingress_tbl_switching", keys=["00:01:02:03:04:05", 0], action=1, data=[9])
+        self.table_add(table="ingress_tbl_switching", key=["00:01:02:03:04:05", 0], action=1, data=[9])
         udp_pkt_1 = testutils.simple_udp_packet(ip_src="10.0.0.1", ip_dst="10.0.0.2",
                                                 udp_sport=1234, udp_dport=50051)
         tcp_pkt_1 = testutils.simple_tcp_packet(ip_src="10.0.0.1", ip_dst="10.0.0.2",
@@ -263,8 +263,8 @@ class ACLTest(L2L3SwitchTest):
                                                 udp_sport=80, udp_dport=8080)
         tcp_pkt_2 = testutils.simple_tcp_packet(ip_src="10.0.0.1", ip_dst="10.0.0.2",
                                                 tcp_sport=80, tcp_dport=8080)
-        self.table_add(table="ingress_tbl_acl", keys=["10.0.0.1", "10.0.0.2", 0x11, 80, 8080], action=1)
-        self.table_add(table="ingress_tbl_acl", keys=["10.0.0.1", "10.0.0.2", 0x6, 80, 8080], action=1)
+        self.table_add(table="ingress_tbl_acl", key=["10.0.0.1", "10.0.0.2", 0x11, 80, 8080], action=1)
+        self.table_add(table="ingress_tbl_acl", key=["10.0.0.1", "10.0.0.2", 0x6, 80, 8080], action=1)
 
         testutils.send_packet(self, PORT0, udp_pkt_1)
         testutils.verify_packet(self, udp_pkt_1, PORT5)
@@ -280,7 +280,7 @@ class ACLTest(L2L3SwitchTest):
 class PortCountersTest(L2L3SwitchTest):
 
     def runTest(self):
-        self.table_add(table="ingress_tbl_switching", keys=["00:00:00:00:00:03", 1], action=1, data=[8])
+        self.table_add(table="ingress_tbl_switching", key=["00:00:00:00:00:03", 1], action=1, data=[8])
         pkt = testutils.simple_udp_packet(eth_dst="00:00:00:00:00:03")
         pkt = pkt_add_vlan(pkt, vlan_vid=1)
 
@@ -293,5 +293,5 @@ class PortCountersTest(L2L3SwitchTest):
             ig_bytes += len(pkt)
             eg_bytes = ig_bytes + (4*(i+1))
             pkts_cnt = i + 1
-            self.counter_verify(name="ingress_in_pkts", keys=[5], bytes=ig_bytes, packets=pkts_cnt)
+            self.counter_verify(name="ingress_in_pkts", key=[5], bytes=ig_bytes, packets=pkts_cnt)
             self.verify_map_entry("egress_tbl_vlan_egress", "8 00 00 00", "02 00 00 00 01 00 00 00 {} 00 00 00 0{} 00 00 00".format(hex(eg_bytes).split('x')[-1], pkts_cnt))

--- a/backends/ebpf/tests/ptf/meters.py
+++ b/backends/ebpf/tests/ptf/meters.py
@@ -180,7 +180,7 @@ class MeterActionPSATest(P4EbpfTest):
         # cir, pir -> 10 Mb/s -> 1,25 MB/s, cbs, pbs -> bs (10 ms) -> 6250 B
         self.meter_update(name="ingress_meter1", index=0,
                           pir=1250000, pbs=6250, cir=1250000, cbs=6250)
-        self.table_add(table="ingress_tbl_fwd", keys=[4], action=1, data=[5])
+        self.table_add(table="ingress_tbl_fwd", key=[4], action=1, data=[5])
 
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet(self, pkt, PORT1)
@@ -227,7 +227,7 @@ class DirectMeterPSATest(P4EbpfTest):
         pkt = testutils.simple_ip_packet()
 
         # cir, pir -> 10 Mb/s, cbs, pbs -> bs (10 ms) -> 6250 B
-        self.table_add(table="ingress_tbl_fwd", keys=[4], action=1, data="5",
+        self.table_add(table="ingress_tbl_fwd", key=[4], action=1, data="5",
                        meters={"ingress_meter1": {"pir": 1250000, "pbs": 6250, "cir": 1250000, "cbs": 6250}})
 
         testutils.send_packet(self, PORT0, pkt)
@@ -253,7 +253,7 @@ class DirectMeterColorAwarePSATest(P4EbpfTest):
         pkt = testutils.simple_ip_packet()
 
         # cir, pir -> 10 Mb/s, cbs, pbs -> bs (10 ms) -> 6250 B
-        self.table_add(table="ingress_tbl_fwd", keys=[4], action=1, data="5",
+        self.table_add(table="ingress_tbl_fwd", key=[4], action=1, data="5",
                        meters={"ingress_meter1": {"pir": 1250000, "pbs": 6250, "cir": 1250000, "cbs": 6250}})
 
         testutils.send_packet(self, PORT0, pkt)
@@ -279,7 +279,7 @@ class DirectAndIndirectMeterPSATest(P4EbpfTest):
         pkt = testutils.simple_ip_packet()
 
         # cir, pir -> 10 Mb/s, cbs, pbs -> bs (10 ms) -> 6250 B
-        self.table_add(table="ingress_tbl_fwd", keys=[4], action=1, data="5",
+        self.table_add(table="ingress_tbl_fwd", key=[4], action=1, data="5",
                        meters={"ingress_direct_meter": {"pir": 1250000, "pbs": 6250, "cir": 1250000, "cbs": 6250}})
 
         # cir, pir -> 10 Mb/s, cbs, pbs -> bs (10 ms) -> 6250 B
@@ -326,7 +326,7 @@ class DirectTwoMetersPSATest(P4EbpfTest):
         pkt = testutils.simple_ip_packet()
 
         # cir, pir -> 10 Mb/s, cbs, pbs -> bs (10 ms) -> 6250 B
-        self.table_add(table="ingress_tbl_fwd", keys=[4], action=1, data=[5],
+        self.table_add(table="ingress_tbl_fwd", key=[4], action=1, data=[5],
                        meters={"ingress_meter1": {"pir": 1250000, "pbs": 6250, "cir": 1250000, "cbs": 6250},
                                "ingress_meter2": {"pir": 1250000, "pbs": 6250, "cir": 1250000, "cbs": 6250}})
 
@@ -358,7 +358,7 @@ class DirectAndCounterMeterPSATest(P4EbpfTest):
         pkt = testutils.simple_ip_packet()
 
         # cir, pir -> 10 Mb/s, cbs, pbs -> bs (10 ms) -> 6250 B
-        self.table_add(table="ingress_tbl_fwd", keys=[4], action=1, data=[5],
+        self.table_add(table="ingress_tbl_fwd", key=[4], action=1, data=[5],
                        counters={"ingress_counter1": {"packets": 1}},
                        meters={"ingress_meter1": {"pir": 1250000, "pbs": 6250, "cir": 1250000, "cbs": 6250}})
 

--- a/backends/ebpf/tests/ptf/register.py
+++ b/backends/ebpf/tests/ptf/register.py
@@ -24,6 +24,7 @@ PORT1 = 1
 PORT2 = 2
 ALL_PORTS = [PORT0, PORT1, PORT2]
 
+
 class RegisterActionPSATest(P4EbpfTest):
     """
     Test register used in an action.
@@ -43,17 +44,17 @@ class RegisterActionPSATest(P4EbpfTest):
     def runTest(self):
         pkt = testutils.simple_ip_packet()
 
-        self.table_add(table="ingress_tbl_fwd", keys=[4], action=1, data=[5])
+        self.table_add(table="ingress_tbl_fwd", key=[4], action=1, data=[5])
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet(self, pkt, PORT1)  # Checks action run
 
-        self.verify_map_entry(name="ingress_reg", key="hex 05 00 00 00", expected_value="05 00 00 00")
+        self.register_verify(name="ingress_reg", index=["0x5"], expected_value=["0x5"])
 
         # After next action run in register should be stored a new value - 15
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet(self, pkt, PORT1)
 
-        self.verify_map_entry(name="ingress_reg", key="hex 05 00 00 00", expected_value="0f 00 00 00")
+        self.register_verify(name="ingress_reg", index=["0x5"], expected_value=["0xf"])
 
 
 class RegisterApplyPSATest(P4EbpfTest):
@@ -73,11 +74,11 @@ class RegisterApplyPSATest(P4EbpfTest):
         pkt = testutils.simple_ip_packet()
 
         testutils.send_packet(self, PORT0, pkt)
-        self.verify_map_entry(name="ingress_reg", key="hex 05 00 00 00", expected_value="05 00 00 00")
+        self.register_verify(name="ingress_reg", index=["0x5"], expected_value=["0x5"])
 
         # After next action run in register should be stored a new value - 15
         testutils.send_packet(self, PORT0, pkt)
-        self.verify_map_entry(name="ingress_reg", key="hex 05 00 00 00", expected_value="0f 00 00 00")
+        self.register_verify(name="ingress_reg", index=["0x5"], expected_value=["0xf"])
 
 
 class RegisterDefaultPSATest(P4EbpfTest):
@@ -94,7 +95,7 @@ class RegisterDefaultPSATest(P4EbpfTest):
         pkt = testutils.simple_ip_packet()
 
         testutils.send_packet(self, PORT0, pkt)
-        self.verify_map_entry(name="ingress_reg", key="hex 05 00 00 00", expected_value="10 00 00 00")
+        self.register_verify(name="ingress_reg", index=["0x5"], expected_value=["0x10"])
 
 
 class RegisterBigKeyPSATest(P4EbpfTest):
@@ -111,7 +112,7 @@ class RegisterBigKeyPSATest(P4EbpfTest):
         pkt = testutils.simple_ip_packet()
 
         testutils.send_packet(self, PORT0, pkt)
-        self.verify_map_entry(name="ingress_reg", key="hex 05 00 00 00 00 00 00 00", expected_value="10 00 00 00")
+        self.register_verify(name="ingress_reg", index=["0x5"], expected_value=["0x10"])
 
 
 class RegisterStructsPSATest(P4EbpfTest):
@@ -121,6 +122,8 @@ class RegisterStructsPSATest(P4EbpfTest):
     2. P4 application will read a value (0),
     add 5 and write it to the register
     3. Verify a value stored in register (5)
+    4. Set register value to port (0xDA), srcAddr (0x55), dstAddr (0x0)
+    5. Verify a srcAddr field change to 0x0D
     """
     p4_file_path = "p4testdata/register-structs.p4"
 
@@ -128,6 +131,12 @@ class RegisterStructsPSATest(P4EbpfTest):
         pkt = testutils.simple_ip_packet()
 
         testutils.send_packet(self, PORT0, pkt)
-        self.verify_map_entry(name="ingress_reg",
-                              key="hex 05 00 00 00 00 00 00 00 ff ff ff ff ff ff 00 00",
-                              expected_value="00 00 00 00 05 00 00 00 00 00 00 00")
+        self.register_verify(name="ingress_reg", index=["0x5", "0xffffffffffff"],
+                             expected_value=["0x0", "0x5", "0x0"])
+
+        self.register_set(name="ingress_reg", index=["0x5", "0xffffffffffff"],
+                          value=["0xDA", "0x55", "0x0"])
+
+        testutils.send_packet(self, PORT0, pkt)
+        self.register_verify(name="ingress_reg", index=["0x5", "0xffffffffffff"],
+                             expected_value=["0xDA", "0x55", "0x0D"])

--- a/backends/ebpf/tests/ptf/table_implementation.py
+++ b/backends/ebpf/tests/ptf/table_implementation.py
@@ -42,8 +42,8 @@ class SimpleActionProfilePSATest(P4EbpfTest):
         testutils.verify_packet_any_port(self, pkt, ALL_PORTS)
 
         # FIXME: API/CLI for ActionProfile is not done yet, we are using table API/CLI for now
-        self.table_add(table="MyIC_ap", keys=[0x10], action=2, data=[0x1122])
-        self.table_add(table="MyIC_tbl", keys=["11:22:33:44:55:66"], references=[0x10])
+        self.table_add(table="MyIC_ap", key=[0x10], action=2, data=[0x1122])
+        self.table_add(table="MyIC_tbl", key=["11:22:33:44:55:66"], references=[0x10])
 
         testutils.send_packet(self, PORT0, pkt)
         pkt[Ether].type = 0x1122
@@ -57,9 +57,9 @@ class ActionProfileTwoTablesSameInstancePSATest(P4EbpfTest):
     p4_file_path = "p4testdata/action-profile2.p4"
 
     def runTest(self):
-        self.table_add(table="MyIC_ap", keys=[0x10], action=2, data=[0x1122])
-        self.table_add(table="MyIC_tbl", keys=["11:22:33:44:55:66"], references=[0x10])
-        self.table_add(table="MyIC_tbl2", keys=["AA:BB:CC:DD:EE:FF"], references=[0x10])
+        self.table_add(table="MyIC_ap", key=[0x10], action=2, data=[0x1122])
+        self.table_add(table="MyIC_tbl", key=["11:22:33:44:55:66"], references=[0x10])
+        self.table_add(table="MyIC_tbl2", key=["AA:BB:CC:DD:EE:FF"], references=[0x10])
 
         pkt = testutils.simple_ip_packet(eth_src="11:22:33:44:55:66", eth_dst="22:33:44:55:66:77")
         testutils.send_packet(self, PORT0, pkt)
@@ -80,8 +80,8 @@ class ActionProfileLPMTablePSATest(P4EbpfTest):
 
     def runTest(self):
         # Match all 11:22:33:44:55:xx MAC addresses
-        self.table_add(table="MyIC_tbl", keys=["0x112233445500/40"], references=[0x10])
-        self.table_add(table="MyIC_ap", keys=[0x10], action=2, data=[0x1122])
+        self.table_add(table="MyIC_tbl", key=["0x112233445500/40"], references=[0x10])
+        self.table_add(table="MyIC_ap", key=[0x10], action=2, data=[0x1122])
 
         pkt = testutils.simple_ip_packet(eth_src="AA:BB:CC:DD:EE:FF", eth_dst="22:33:44:55:66:77")
         testutils.send_packet(self, PORT0, pkt)
@@ -103,10 +103,10 @@ class ActionProfileActionRunPSATest(P4EbpfTest):
     p4_file_path = "p4testdata/action-profile-action-run.p4"
 
     def runTest(self):
-        self.table_add(table="MyIC_ap", keys=[0x10], action=2, data=[0x1122])
-        self.table_add(table="MyIC_ap", keys=[0x20], action=1, data=["AA:BB:CC:DD:EE:FF"])
-        self.table_add(table="MyIC_tbl", keys=["11:22:33:44:55:66"], references=[0x10])
-        self.table_add(table="MyIC_tbl", keys=["AA:BB:CC:DD:EE:FF"], references=[0x20])
+        self.table_add(table="MyIC_ap", key=[0x10], action=2, data=[0x1122])
+        self.table_add(table="MyIC_ap", key=[0x20], action=1, data=["AA:BB:CC:DD:EE:FF"])
+        self.table_add(table="MyIC_tbl", key=["11:22:33:44:55:66"], references=[0x10])
+        self.table_add(table="MyIC_tbl", key=["AA:BB:CC:DD:EE:FF"], references=[0x20])
 
         # action MyIC_a1
         pkt = testutils.simple_ip_packet(eth_src="AA:BB:CC:DD:EE:FF", eth_dst="22:33:44:55:66:77")
@@ -132,8 +132,8 @@ class ActionProfileHitPSATest(P4EbpfTest):
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_no_other_packets(self)
 
-        self.table_add(table="MyIC_ap", keys=[0x10], action=2, data=[0x1122])
-        self.table_add(table="MyIC_tbl", keys=["11:22:33:44:55:66"], references=[0x10])
+        self.table_add(table="MyIC_ap", key=[0x10], action=2, data=[0x1122])
+        self.table_add(table="MyIC_tbl", key=["11:22:33:44:55:66"], references=[0x10])
 
         testutils.send_packet(self, PORT0, pkt)
         pkt[Ether].type = 0x1122
@@ -166,8 +166,8 @@ class ActionSelectorTest(P4EbpfTest):
         self.default_group_ports = [PORT3, PORT4, PORT5]
 
         if table:
-            self.table_add(table=table, keys=["02:22:33:44:55:66"], references=["0x2"])
-            self.table_add(table=table, keys=["07:22:33:44:55:66"], references=["group {}".format(self.group_id)])
+            self.table_add(table=table, key=["02:22:33:44:55:66"], references=["0x2"])
+            self.table_add(table=table, key=["07:22:33:44:55:66"], references=["group {}".format(self.group_id)])
 
 
 class SimpleActionSelectorPSATest(ActionSelectorTest):
@@ -215,7 +215,7 @@ class ActionSelectorTwoTablesSameInstancePSATest(ActionSelectorTest):
 
     def runTest(self):
         self.create_default_rule_set(table="MyIC_tbl", selector="MyIC_as")
-        self.table_add(table="MyIC_tbl2", keys=[0x1122], references=[3])
+        self.table_add(table="MyIC_tbl2", key=[0x1122], references=[3])
 
         pkt = testutils.simple_ip_packet(eth_src="02:22:33:44:55:66", eth_dst="22:33:44:55:66:77")
         testutils.send_packet(self, PORT0, pkt)
@@ -240,7 +240,7 @@ class ActionSelectorDefaultEmptyGroupActionPSATest(ActionSelectorTest):
         testutils.verify_no_other_packets(self)
 
         gid = self.action_selector_create_empty_group(selector="MyIC_as")
-        self.table_add(table="MyIC_tbl", keys=["08:22:33:44:55:66"], references=["group {}".format(gid)])
+        self.table_add(table="MyIC_tbl", key=["08:22:33:44:55:66"], references=["group {}".format(gid)])
 
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet(self, pkt, PORT1)
@@ -260,7 +260,7 @@ class ActionSelectorMultipleSelectorsPSATest(ActionSelectorTest):
 
     def runTest(self):
         self.create_default_rule_set(table="MyIC_tbl", selector="MyIC_as")
-        self.table_add(table="MyIC_tbl", keys=["07:22:33:44:55:67"], references=["group {}".format(self.group_id)])
+        self.table_add(table="MyIC_tbl", key=["07:22:33:44:55:67"], references=["group {}".format(self.group_id)])
 
         allowed_ports = self.default_group_ports
         pkt = testutils.simple_ip_packet(eth_src="07:22:33:44:55:66", eth_dst="22:33:44:55:66:77")
@@ -293,7 +293,7 @@ class ActionSelectorMultipleSelectorsTwoTablesPSATest(ActionSelectorTest):
 
     def runTest(self):
         self.create_default_rule_set(table="MyIC_tbl", selector="MyIC_as")
-        self.table_add(table="MyIC_tbl2", keys=["AA:BB:CC:DD:EE:FF"], references=["group {}".format(self.group_id)])
+        self.table_add(table="MyIC_tbl2", key=["AA:BB:CC:DD:EE:FF"], references=["group {}".format(self.group_id)])
 
         pkt = testutils.simple_ip_packet(eth_src="07:22:33:44:55:66", eth_dst="22:33:44:55:66:77")
         testutils.send_packet(self, PORT0, pkt)
@@ -313,9 +313,9 @@ class ActionSelectorLPMTablePSATest(ActionSelectorTest):
     def runTest(self):
         self.create_default_rule_set(table=None, selector="MyIC_as")
         # Match all 00:22:02:44:55:xx MAC addresses into action ref 2
-        self.table_add(table="MyIC_tbl", keys=["0x002202445500/40"], references=[2])
+        self.table_add(table="MyIC_tbl", key=["0x002202445500/40"], references=[2])
         # Match all 00:22:07:44:55:xx MAC addresses into group g7
-        self.table_add(table="MyIC_tbl", keys=["0x2207445500/40"], references=["group {}".format(self.group_id)])
+        self.table_add(table="MyIC_tbl", key=["0x2207445500/40"], references=["group {}".format(self.group_id)])
 
         pkt = testutils.simple_ip_packet(eth_src="00:22:07:44:55:66", eth_dst="22:33:44:55:66:77")
         testutils.send_packet(self, PORT0, pkt)
@@ -338,8 +338,8 @@ class ActionSelectorActionRunPSATest(ActionSelectorTest):
     def runTest(self):
         ref1 = self.action_selector_add_action(selector="MyIC_as", action=1, data=[5])
         ref2 = self.action_selector_add_action(selector="MyIC_as", action=0, data=[])
-        self.table_add(table="MyIC_tbl", keys=["02:22:33:44:55:66"], references=[ref1])
-        self.table_add(table="MyIC_tbl", keys=["03:22:33:44:55:66"], references=[ref2])
+        self.table_add(table="MyIC_tbl", key=["02:22:33:44:55:66"], references=[ref1])
+        self.table_add(table="MyIC_tbl", key=["03:22:33:44:55:66"], references=[ref2])
 
         pkt = testutils.simple_ip_packet(eth_src="02:22:33:44:55:66", eth_dst="22:33:44:55:66:77")
         testutils.send_packet(self, PORT0, pkt)

--- a/backends/ebpf/tests/ptf/test.py
+++ b/backends/ebpf/tests/ptf/test.py
@@ -199,19 +199,19 @@ class SimpleLpmP4PSATest(P4EbpfTest):
 
     def runTest(self):
         # This command adds LPM entry 10.10.0.0/16 with action forwarding on port 6 (PORT2 in ptf)
-        self.table_add(table="ingress_tbl_fwd_lpm", keys=["10.10.0.0/16"], action=1, data=[6])
-        self.table_add(table="ingress_tbl_fwd_lpm", keys=["10.10.10.10/8"], action=0)
+        self.table_add(table="ingress_tbl_fwd_lpm", key=["10.10.0.0/16"], action=1, data=[6])
+        self.table_add(table="ingress_tbl_fwd_lpm", key=["10.10.10.10/8"], action=0)
         pkt = testutils.simple_ip_packet(ip_src='1.1.1.1', ip_dst='10.10.11.11')
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet(self, pkt, PORT2)
 
-        self.table_add(table="ingress_tbl_fwd_lpm", keys=["192.168.2.1/24"], action=1, data=[5])
+        self.table_add(table="ingress_tbl_fwd_lpm", key=["192.168.2.1/24"], action=1, data=[5])
         pkt = testutils.simple_ip_packet(ip_src='1.1.1.1', ip_dst='192.168.2.1')
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet(self, pkt, PORT1)
 
 
-class SimpleLpmP4TwoKeysPSATest(P4EbpfTest):
+class SimpleLpmP4TwokeyPSATest(P4EbpfTest):
 
     p4_file_path = "p4testdata/psa-lpm-two-keys.p4"
 
@@ -219,14 +219,14 @@ class SimpleLpmP4TwoKeysPSATest(P4EbpfTest):
         pkt = testutils.simple_ip_packet(ip_src='1.2.3.4', ip_dst='10.10.11.11')
         # This command adds LPM entry 10.10.11.0/24 with action forwarding on port 6 (PORT2 in ptf)
         # Note that prefix value has to be a sum of exact fields size and lpm prefix
-        self.table_add(table="ingress_tbl_fwd_exact_lpm", keys=["1.2.3.4", "10.10.11.0/24"], action=1, data=[6])
+        self.table_add(table="ingress_tbl_fwd_exact_lpm", key=["1.2.3.4", "10.10.11.0/24"], action=1, data=[6])
 
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet(self, pkt, PORT2)
 
         pkt = testutils.simple_ip_packet(ip_src='1.2.3.4', ip_dst='192.168.2.1')
         # This command adds LPM entry 192.168.2.1/24 with action forwarding on port 5 (PORT1 in ptf)
-        self.table_add(table="ingress_tbl_fwd_exact_lpm", keys=["1.2.3.4", "192.168.2.1/24"], action=1, data=[5])
+        self.table_add(table="ingress_tbl_fwd_exact_lpm", key=["1.2.3.4", "192.168.2.1/24"], action=1, data=[5])
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet(self, pkt, PORT1)
 
@@ -375,10 +375,10 @@ class CountersPSATest(P4EbpfTest):
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet_any_port(self, pkt, ALL_PORTS)
 
-        self.counter_verify(name="ingress_test1_cnt", keys=[1], bytes=100)
-        self.counter_verify(name="ingress_test2_cnt", keys=[1], packets=1)
-        self.counter_verify(name="ingress_test3_cnt", keys=[1], bytes=100, packets=1)
-        self.counter_verify(name="ingress_action_cnt", keys=[5], bytes=100, packets=1)
+        self.counter_verify(name="ingress_test1_cnt", key=[1], bytes=100)
+        self.counter_verify(name="ingress_test2_cnt", key=[1], packets=1)
+        self.counter_verify(name="ingress_test3_cnt", key=[1], bytes=100, packets=1)
+        self.counter_verify(name="ingress_action_cnt", key=[5], bytes=100, packets=1)
 
         pkt = testutils.simple_ip_packet(eth_dst='00:11:22:33:44:55',
                                          eth_src='00:AA:00:00:01:FE',
@@ -386,31 +386,31 @@ class CountersPSATest(P4EbpfTest):
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet_any_port(self, pkt, ALL_PORTS)
 
-        self.counter_verify(name="ingress_test1_cnt", keys=[0x1fe], bytes=199)
-        self.counter_verify(name="ingress_test2_cnt", keys=[0x1fe], packets=1)
-        self.counter_verify(name="ingress_test3_cnt", keys=[0x1fe], bytes=199, packets=1)
-        self.counter_verify(name="ingress_action_cnt", keys=[5], bytes=299, packets=2)
+        self.counter_verify(name="ingress_test1_cnt", key=[0x1fe], bytes=199)
+        self.counter_verify(name="ingress_test2_cnt", key=[0x1fe], packets=1)
+        self.counter_verify(name="ingress_test3_cnt", key=[0x1fe], bytes=199, packets=1)
+        self.counter_verify(name="ingress_action_cnt", key=[5], bytes=299, packets=2)
 
 
 class DirectCountersPSATest(P4EbpfTest):
     p4_file_path = "p4testdata/direct-counters.p4"
 
     def runTest(self):
-        self.table_add(table="ingress_tbl1", keys=["10.0.0.0"], action=1)
-        self.table_add(table="ingress_tbl2", keys=["10.0.0.1"], action=2)
-        self.table_add(table="ingress_tbl2", keys=["10.0.0.2"], action=3)
+        self.table_add(table="ingress_tbl1", key=["10.0.0.0"], action=1)
+        self.table_add(table="ingress_tbl2", key=["10.0.0.1"], action=2)
+        self.table_add(table="ingress_tbl2", key=["10.0.0.2"], action=3)
 
         for i in range(3):
             pkt = testutils.simple_ip_packet(pktlen=100, ip_src='10.0.0.{}'.format(i))
             testutils.send_packet(self, PORT0, pkt)
             testutils.verify_packet_any_port(self, pkt, ALL_PORTS)
 
-        self.table_verify(table="ingress_tbl1", keys=["10.0.0.0"], action=1,
+        self.table_verify(table="ingress_tbl1", key=["10.0.0.0"], action=1,
                           counters={"ingress_test3_cnt": {"bytes": 100, "packets": 1}})
-        self.table_verify(table="ingress_tbl2", keys=["10.0.0.1"], action=2,
+        self.table_verify(table="ingress_tbl2", key=["10.0.0.1"], action=2,
                           counters={"ingress_test2_cnt": {"packets": 1},
                                     "ingress_test3_cnt": {"bytes": 0, "packets": 0}})
-        self.table_verify(table="ingress_tbl2", keys=["10.0.0.2"], action=3,
+        self.table_verify(table="ingress_tbl2", key=["10.0.0.2"], action=3,
                           counters={"ingress_test2_cnt": {"packets": 1},
                                     "ingress_test3_cnt": {"bytes": 100, "packets": 1}})
 
@@ -468,7 +468,7 @@ class RandomPSATest(P4EbpfTest):
             self.fail("Value {} out of range [{}, {}]".format(value, min_value, max_value))
 
     def runTest(self):
-        self.table_add(table="MyIC_tbl_fwd", keys=[4], action=1, data=[5])
+        self.table_add(table="MyIC_tbl_fwd", key=[4], action=1, data=[5])
         pkt = Ether() / self.RandomHeader()
         mask = Mask(pkt)
         mask.set_do_not_care_scapy(self.RandomHeader, "f1")
@@ -522,33 +522,33 @@ class PSATernaryTest(P4EbpfTest):
         # flow rules for 'tbl_ternary_0'
         # 1. ipv4.srcAddr=1.2.3.4/0xffffff00 => action 0 priority 1
         # 2. ipv4.srcAddr=1.2.3.4/0xffff00ff => action 1 priority 10
-        self.table_add(table="ingress_tbl_ternary_0", keys=["1.2.3.4^0xffffff00"], action=0, priority=1)
-        self.table_add(table="ingress_tbl_ternary_0", keys=["1.2.3.4^0xffff00ff"], action=1, priority=10)
+        self.table_add(table="ingress_tbl_ternary_0", key=["1.2.3.4^0xffffff00"], action=0, priority=1)
+        self.table_add(table="ingress_tbl_ternary_0", key=["1.2.3.4^0xffff00ff"], action=1, priority=10)
 
         # flow rules for 'tbl_ternary_1'
         # 1. ipv4.diffserv=0x00/0x00, ipv4.dstAddr=192.168.2.1/24 => action 0 priority 1
         # 2. ipv4.diffserv=0x00/0xff, ipv4.dstAddr=192.168.2.1/24 => action 1 priority 10
-        self.table_add(table="ingress_tbl_ternary_1", keys=["192.168.2.1/24", "0^0"], action=0, priority=1)
-        self.table_add(table="ingress_tbl_ternary_1", keys=["192.168.2.1/24", "0^0xFF"], action=1, priority=10)
+        self.table_add(table="ingress_tbl_ternary_1", key=["192.168.2.1/24", "0^0"], action=0, priority=1)
+        self.table_add(table="ingress_tbl_ternary_1", key=["192.168.2.1/24", "0^0xFF"], action=1, priority=10)
 
         # flow rules 'tbl_ternary_2':
         # 1. ipv4.protocol=0x11, ipv4.diffserv=0x00/0x00, ipv4.dstAddr=192.168.2.1/16 => action 0 priority 1
         # 2. ipv4.protocol=0x11, ipv4.diffserv=0x00/0xff, ipv4.dstAddr=192.168.2.1/16 => action 1 priority 10
-        self.table_add(table="ingress_tbl_ternary_2", keys=["192.168.2.1/16", "0x11", "0^0"], action=0, priority=1)
-        self.table_add(table="ingress_tbl_ternary_2", keys=["192.168.2.1/16", "0x11", "0^0xFF"], action=1, priority=10)
+        self.table_add(table="ingress_tbl_ternary_2", key=["192.168.2.1/16", "0x11", "0^0"], action=0, priority=1)
+        self.table_add(table="ingress_tbl_ternary_2", key=["192.168.2.1/16", "0x11", "0^0xFF"], action=1, priority=10)
 
         # flow rules 'tbl_ternary_3':
         # 1. ipv4.protocol=0x7, ipv4.diffserv=selector, ipv4.dstAddr=0xffffffff^0xffffffff => action 0 priority 1
         # 2. ipv4.protocol=0x7, ipv4.diffserv=selector, ipv4.dstAddr=0x0^0x0 => action 1 priority 10
         ref1 = self.action_selector_add_action(selector="ingress_as", action=0, data=[])
         ref2 = self.action_selector_add_action(selector="ingress_as", action=1, data=[])
-        self.table_add(table="ingress_tbl_ternary_3", keys=["0xffffffff^0xffffffff", "0x7"], references=[ref1], priority=1)
-        self.table_add(table="ingress_tbl_ternary_3", keys=["0x0^0x0", "0x7"], references=[ref2], priority=10)
+        self.table_add(table="ingress_tbl_ternary_3", key=["0xffffffff^0xffffffff", "0x7"], references=[ref1], priority=1)
+        self.table_add(table="ingress_tbl_ternary_3", key=["0x0^0x0", "0x7"], references=[ref2], priority=10)
 
         # flow rules 'tbl_ternary_4':
         # 2. hdr.ethernet.srcAddr=00:00:33:44:55:00^00:00:FF:FF:FF:00 => action 1 priority 10
-        self.table_add(table="ingress_ap", keys=[0x10], action=1, data=[])
-        self.table_add(table="ingress_tbl_ternary_4", keys=["00:00:33:44:55:00^00:00:FF:FF:FF:00"],
+        self.table_add(table="ingress_ap", key=[0x10], action=1, data=[])
+        self.table_add(table="ingress_tbl_ternary_4", key=["00:00:33:44:55:00^00:00:FF:FF:FF:00"],
                        references=["0x10"], priority=10)
 
         pkt = testutils.simple_udp_packet(eth_src="11:22:33:44:55:66", ip_src='1.2.3.4', ip_dst='192.168.2.1')

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -82,7 +82,7 @@ function install_ptf_ebpf_test_deps() (
   git clone --recursive https://github.com/P4-Research/psabpf.git /tmp/psabpf
   cd /tmp/psabpf
   # FIXME: psabpf is under heavy development, later use git tags when it will be ready to use
-  git reset --hard 9cfa06c
+  git reset --hard bbfbf0b
   ./build_libbpf.sh
   mkdir build
   cd build


### PR DESCRIPTION
- [X]  Add `register_get` and `register_set` commands to PTF tests.
- [X]  Use `key` param name in singular form.